### PR TITLE
Update addy strat

### DIFF
--- a/data/strats.json
+++ b/data/strats.json
@@ -291,7 +291,7 @@
   },
   {
     "name": "adamant-addy",
-    "address": "0xbeCDA5b41Ebbd55E8D668Bc16d2b6afAF2420b0C",
+    "address": "0xcF17BCB6C6dF9b746f77286A27a7bf037974f657",
     "interval": 1,
     "harvestSignature": "0x4641257d",
     "depositsPaused": false,


### PR DESCRIPTION
Strat never showed up as a contract in Maticvigil UI. I redeployed the same vault and contract to get new addresses, and they both showed up in the UI, as well as verified 